### PR TITLE
Feature/launch league

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,27 @@ This is what i do, to then publish the final `leagueRPC.exe` to Github.
 
 LeagueRPC supports various command-line arguments to enhance flexibility and user customization.
 
-### `--client-id <discord-app-id>`
+✨ Means Recommended.
+
+### `--launch-league <location>` ✨
+
+The `--launch-league` argument allows you to automatically launch the League of Legends client alongside leagueRPC. This feature is designed to make your experience more seamless by integrating the game launch into the RPC setup.
+
+By default, if `--launch-league` is specified without a path, the default installation path will be used:
+```plaintext
+C:\Riot Games\Riot Client\RiotClientServices.exe
+```
+This path is correct for the majority of installations. If your League of Legends client is installed in this location, you do not need to specify the path explicitly.
+
+If you have installed League of Legends in a non-default location, you must provide the path to the RiotClientServices.exe file when using --launch-league. For example, if your game is installed on the D drive, you can start leagueRPC with the game like this:
+
+```powershell
+.\leagueRPC.exe --launch-league "D:\Riot Games\Riot Client\RiotClientServices.exe"
+```
+This command tells leagueRPC to launch the League of Legends client from the specified location.
+
+
+### `--client-id <discord-app-id>` ✨
 Specify a custom Discord client ID for the RPC connection. Defaults to `League of Legends`
 **Example** `.\leagueRPC.exe --client-id 1230607224296968303` - This will show `League of Kittens`
 - **League of Kittens**: `1230607224296968303`
@@ -190,7 +210,7 @@ Hide your League rank on Discord (SoloQ/Flex/TFT/Arena) By default, this will be
 **Example**: `.\leagueRPC.exe --no-rank`
 
 
-### `--show-emojis`
+### `--show-emojis` ✨
 Do you want to show your Online/Away status with a emoji, then add this argument. By default, this will be hidden.
 
 **Example**: `.\leagueRPC.exe --show-emojis`
@@ -217,7 +237,7 @@ Similar to `--wait-for-league`, specify the time (in seconds) to wait for Discor
 Each of these arguments can be combined to tailor the Discord RPC to your preferences.
 
 ```powershell
-.\leagueRPC.exe --client-id 1194034071588851783 --no-stats --no-rank --add-process CustomDiscord --wait-for-league -1 --wait-for-discord 15 --show-emojis 
+.\leagueRPC.exe --client-id 1194034071588851783 --launch-league --no-stats --no-rank --add-process CustomDiscord --wait-for-league -1 --wait-for-discord 15 --show-emojis
 ```
 
 🛑 All of these arguments are optional. No extra argument is needed for the script to function properly. But in case you want to change something, you now can.
@@ -231,7 +251,7 @@ Each of these arguments can be combined to tailor the Discord RPC to your prefer
 5. **Precise In-Game Time Tracking**: The in-game time is calculated with precision. Even if the script stops, when restarted, it will display the correct in-game time, ensuring continuous and accurate representation of your game status.
 6. **Discord Reconnection Window**: While the script only works while Discord is up and running. There are instances where discord could crash. This program will attempt to reconnect to Discord's RPC even if the app is not running. For a period of time, and only exit when too much time has passed. Default is (50) seconds to restart/reconnect Discord.
 7. **Disables Native League Presence**: This application is able to detect, and disable the built in rich presence coming from league, leaving only this one active as your main Presence on discord. This was a huge issue before since it's not easy to disable. And now all you have to do is just start this application before launching the league client, and you will be good to go.
-
+8. **Launches League of legends for you**: To avoid forgetting to start this application before league all the time, you can let the application start league for you. Please read about the `--launch-league` argument to learn more.
 
 ## Tips for Running
 

--- a/league_rpc/__version__.py
+++ b/league_rpc/__version__.py
@@ -1,12 +1,12 @@
 """Set version number of package."""
 
-__version__ = "v2.0.1"
+__version__ = "v2.1.0"
 import requests
 
 RELEASES_PAGE = "https://github.com/Its-Haze/league-rpc/releases"
 
 
-def get_version_from_github() -> str:
+def get_version_from_github() -> str | None:
     """
     Get the latest version of the software from the GitHub repository.
 
@@ -17,15 +17,21 @@ def get_version_from_github() -> str:
         url="https://api.github.com/repos/its-haze/league-rpc/releases/latest",
         timeout=15,
     )
+    if response.status_code != 200:
+        # Probably due to rate limit.. should be handled better.
+        return None
+
     return response.json()["tag_name"]
 
 
-def check_latest_version() -> bool:
+def check_latest_version() -> bool | None:
     """
     Check if the current version of the software is the latest version available.
 
     Returns:
         bool: True if the current version is not the latest version, False otherwise.
     """
-    latest_version: str = get_version_from_github()
+    latest_version: str | None = get_version_from_github()
+    if latest_version is None:
+        return None
     return latest_version > __version__

--- a/league_rpc/__version__.py
+++ b/league_rpc/__version__.py
@@ -1,6 +1,6 @@
 """Set version number of package."""
 
-__version__ = "v2.0.0"
+__version__ = "v2.0.1"
 import requests
 
 RELEASES_PAGE = "https://github.com/Its-Haze/league-rpc/releases"

--- a/league_rpc/champion.py
+++ b/league_rpc/champion.py
@@ -4,6 +4,9 @@ from typing import Any, Optional
 import requests
 import urllib3
 
+from league_rpc.kda import get_gold, get_level
+from league_rpc.latest_version import get_latest_version
+from league_rpc.username import get_summoner_name
 from league_rpc.utils.color import Color
 from league_rpc.utils.const import (
     ALL_GAME_DATA_URL,
@@ -12,10 +15,7 @@ from league_rpc.utils.const import (
     DDRAGON_CHAMPION_DATA,
     GAME_MODE_CONVERT_MAP,
 )
-from league_rpc.kda import get_gold, get_level
-from league_rpc.latest_version import get_latest_version
 from league_rpc.utils.polling import wait_until_exists
-from league_rpc.username import get_summoner_name
 
 urllib3.disable_warnings()
 

--- a/league_rpc/disable_native_rpc/disable.py
+++ b/league_rpc/disable_native_rpc/disable.py
@@ -65,11 +65,11 @@ def check_and_modify_json(file_path: str) -> None:
 
     if modify_json_data(data=data):
         print(
-            f"{Color.orange}Native league rpc found. Will disable it now.{Color.reset}"
+            f"\n{Color.orange}Native league rpc found. Will disable it now.{Color.reset}"
         )
         save_json_file(file_path=file_path, data=data)
         print(
-            f"{Color.green}Successfully disabled League Native Rich Presence{Color.reset}"
+            f"{Color.green}Successfully disabled League Native Rich Presence{Color.reset}\n"
         )
 
     # For debugging purposes only.

--- a/league_rpc/kda.py
+++ b/league_rpc/kda.py
@@ -1,8 +1,8 @@
 import urllib3
 from requests import Response
 
-from league_rpc.utils.polling import wait_until_exists
 from league_rpc.username import get_summoner_name
+from league_rpc.utils.polling import wait_until_exists
 
 urllib3.disable_warnings()
 

--- a/league_rpc/lcu_api/lcu_connector.py
+++ b/league_rpc/lcu_api/lcu_connector.py
@@ -1,12 +1,12 @@
+import time
 from argparse import Namespace
 from typing import Any, Optional
 
 from aiohttp import ClientResponse
-from lcu_driver.connection import Connection
-from lcu_driver.events.responses import WebsocketEventResponse
-from pypresence import Presence
+from lcu_driver.connection import Connection  # type:ignore
+from lcu_driver.events.responses import WebsocketEventResponse  # type:ignore
+from pypresence import Presence  # type:ignore
 
-from league_rpc.utils.color import Color
 from league_rpc.disable_native_rpc.disable import check_plugin_status, find_game_path
 from league_rpc.lcu_api.base_data import gather_base_data
 from league_rpc.models.client_data import ArenaStats, ClientData, RankedStats, TFTStats
@@ -19,6 +19,7 @@ from league_rpc.models.lcu.current_queue import LolGameQueuesQueue
 from league_rpc.models.lcu.current_summoner import Summoner
 from league_rpc.models.module_data import ModuleData
 from league_rpc.models.rpc_updater import RPCUpdater
+from league_rpc.utils.color import Color
 
 module_data = ModuleData()
 rpc_updater = RPCUpdater()
@@ -29,8 +30,10 @@ rpc_updater = RPCUpdater()
 @module_data.connector.ready  # type:ignore
 async def connect(connection: Connection) -> None:
     print(f"{Color.green}Successfully connected to the League Client API.{Color.reset}")
+    time.sleep(2)  # Give the client some time to load
 
     print(f"\n{Color.orange}Gathering base data.{Color.reset}")
+    time.sleep(2)
     await gather_base_data(connection=connection, module_data=module_data)
 
     print(f"{Color.green}Successfully gathered base data.{Color.reset}")

--- a/league_rpc/models/rpc_updater.py
+++ b/league_rpc/models/rpc_updater.py
@@ -14,8 +14,13 @@ import time
 from dataclasses import dataclass
 from threading import Timer
 
-from pypresence import Presence
+from pypresence import Presence  # type:ignore
 
+from league_rpc.lcu_api.lcu_connector import ModuleData
+from league_rpc.models.client_data import ClientData
+from league_rpc.models.lcu.current_chat_status import LolChatUser
+from league_rpc.models.lcu.current_ranked_stats import ArenaStats, RankedStats, TFTStats
+from league_rpc.models.lcu.gameflow_phase import GameFlowPhase
 from league_rpc.utils.const import (
     BASE_MAP_ICON_URL,
     GAME_MODE_CONVERT_MAP,
@@ -25,11 +30,6 @@ from league_rpc.utils.const import (
     RANKED_TYPE_MAPPER,
     SMALL_TEXT,
 )
-from league_rpc.lcu_api.lcu_connector import ModuleData
-from league_rpc.models.client_data import ClientData
-from league_rpc.models.lcu.current_chat_status import LolChatUser
-from league_rpc.models.lcu.current_ranked_stats import ArenaStats, RankedStats, TFTStats
-from league_rpc.models.lcu.gameflow_phase import GameFlowPhase
 
 
 # As some events are called multiple times, we should limit the amount of updates to the RPC.

--- a/league_rpc/utils/const.py
+++ b/league_rpc/utils/const.py
@@ -82,3 +82,6 @@ RANKED_TYPE_MAPPER = {
     "RANKED_TFT_TURBO": "Teamfight Tactics (Hyper Roll)",
     "CHERRY": "Arena",
 }
+
+DEFAULT_LEAGUE_CLIENT_EXE_PATH = "C:\\Riot Games\\Riot Client\\RiotClientServices.exe"
+DEFAULT_LEAGUE_CLIENT_EXECUTABLE = "RiotClientServices.exe"

--- a/league_rpc/utils/launch_league.py
+++ b/league_rpc/utils/launch_league.py
@@ -1,0 +1,25 @@
+import subprocess
+import time
+from argparse import Namespace
+
+from league_rpc.utils.const import DEFAULT_LEAGUE_CLIENT_EXECUTABLE
+
+
+def launch_league_client(cli_args: Namespace) -> None:
+    """Launch the League Client with the given path or the default path."""
+
+    # If the user wants to launch the league client.
+    # we should use the path given by the user to launch the client with subprocess.
+    if DEFAULT_LEAGUE_CLIENT_EXECUTABLE in cli_args.launch_league:
+        # If the default path is given, use the default launch arguments for league.
+        commands = [
+            cli_args.launch_league,
+            "--launch-product=league_of_legends",
+            "--launch-patchline=live",
+        ]
+    else:
+        # If a custom path has been set, just execute that path
+        commands = [cli_args.launch_league]
+
+    subprocess.Popen(commands, shell=True)
+    time.sleep(5)


### PR DESCRIPTION
Add launch-league argument, as a default when starting leagueRPC.

This will execute the default client exe, but if none is found., continue as normal.

User can specify path if needed.