### PR TITLE
Fix leagueRPC to work on patch 14.10 API

### DIFF
--- a/league_rpc/__version__.py
+++ b/league_rpc/__version__.py
@@ -1,6 +1,6 @@
 """Set version number of package."""
 
-__version__ = "v2.1.0"
+__version__ = "v2.1.1"
 import requests
 
 RELEASES_PAGE = "https://github.com/Its-Haze/league-rpc/releases"

--- a/league_rpc/champion.py
+++ b/league_rpc/champion.py
@@ -6,7 +6,7 @@ import urllib3
 
 from league_rpc.kda import get_gold, get_level
 from league_rpc.latest_version import get_latest_version
-from league_rpc.username import get_summoner_name
+from league_rpc.username import get_riot_id
 from league_rpc.utils.color import Color
 from league_rpc.utils.const import (
     ALL_GAME_DATA_URL,
@@ -35,7 +35,7 @@ def gather_ingame_information() -> tuple[str, str, int, str, int, int]:
     Get the current playing champion name.
     """
     all_game_data_url = ALL_GAME_DATA_URL
-    your_summoner_name: str = get_summoner_name()
+    your_summoner_name: str = get_riot_id()
 
     champion_name: str | None = None
     skin_id: int | None = None
@@ -106,7 +106,7 @@ def gather_league_data(
     skin_ids: list[int] = []
 
     for player in parsed_data["allPlayers"]:
-        if player["summonerName"] == summoners_name:
+        if player["riotId"] == summoners_name:
             raw_champion_name: str = player["rawChampionName"].split("_")[-1]
             champion_data: dict[str, Any] = get_specific_champion_data(
                 name=raw_champion_name

--- a/league_rpc/kda.py
+++ b/league_rpc/kda.py
@@ -1,7 +1,7 @@
 import urllib3
 from requests import Response
 
-from league_rpc.username import get_summoner_name
+from league_rpc.username import get_riot_id
 from league_rpc.utils.polling import wait_until_exists
 
 urllib3.disable_warnings()
@@ -68,13 +68,14 @@ def get_creepscore() -> str:
 
 def get_current_user_stats() -> Response | None:
     """
-    Request data from playerscores?summonerName and return the response.
+    Request data from playerscores?riotId and return the response.
     """
-    your_summoner_name = get_summoner_name()
-    if your_summoner_name:
+    your_riot_id = get_riot_id()
+    if your_riot_id:
         # If the summoner name is not found, we don't want the KDA.
-
-        player_score_url = f"https://127.0.0.1:2999/liveclientdata/playerscores?summonerName={your_summoner_name}"
+        player_score_url = (
+            f"https://127.0.0.1:2999/liveclientdata/playerscores?riotId={your_riot_id}"
+        )
         if response := wait_until_exists(url=player_score_url):
             return response
     return None

--- a/league_rpc/username.py
+++ b/league_rpc/username.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import urllib3
 
 from league_rpc.utils.polling import wait_until_exists
@@ -5,15 +7,16 @@ from league_rpc.utils.polling import wait_until_exists
 urllib3.disable_warnings()
 
 
-def get_summoner_name(with_discriminator: bool = False) -> str:
+def get_riot_id(without_discriminator: bool = False) -> str:
     """
     Gets the current summoner name.
 
-    if with_discriminator is True, the function will return a summoners name with #EUW / #EUNE etc
-        Defaults to not include it.
+    if without_discriminator is True, the function will not return a summoners name with #EUW / #EUNE etc
+        Defaults to include it.
 
     """
-    url = "https://127.0.0.1:2999/liveclientdata/activeplayername"
+
+    url = "https://127.0.0.1:2999/liveclientdata/playerlist"
     if response := wait_until_exists(
         url=url,
         custom_message="""
@@ -21,7 +24,10 @@ def get_summoner_name(with_discriminator: bool = False) -> str:
             Contact @haze.dev on discord, or submit a ticket on Github.
             """,
     ):
-        name = str(response.json())
-        return name if with_discriminator else name.split("#", maxsplit=1)[0]
+        _response: list[dict[str, Any]] = response.json()
+        name_without_discriminator = _response[0]["riotIdGameName"]
+        riot_id = _response[0]["riotId"]
+
+        return name_without_discriminator if without_discriminator else riot_id
 
     return ""


### PR DESCRIPTION
Riot updated their API, causing LeagueRPC and many other programs to crash..

The reason for this is a change with the way they handle summonerNames.

It's no longer called summonerName, but rather riotId